### PR TITLE
Add choice actions to dialogue

### DIFF
--- a/src/npc/jayson.lua
+++ b/src/npc/jayson.lua
@@ -16,7 +16,7 @@ function jayson:onInteract()
 
     -- Load dialogue from external tree
     local dialogueTree = require("src.npc_dialogue.jayson_dialogue")
-    dialogue:start(dialogueTree)
+    state:set("dialogue", { tree = dialogueTree })
 
     -- Mark that we’ve initiated conversation
     jayson.hasSpoken = true

--- a/src/npc_dialogue/jayson_dialogue.lua
+++ b/src/npc_dialogue/jayson_dialogue.lua
@@ -11,7 +11,9 @@ return {
             { text = "Your assessment is correct. Proceed.", next = "cold_ack" },
             { text = "I escaped something. I don't owe you more.", next = "defensive" },
             { text = "(Say nothing)", next = "silent" },
-            { text = "I used to be one of them. I'm trying not to be.", next = "reveal" }
+            { text = "I used to be one of them. I'm trying not to be.", next = "reveal" },
+            { text = "Got any supplies?", next = "end_convo", reward = { name = "Medkit", type = "healing", effect = 20 } },
+            { text = "Where's the next zone?", next = "map_offer" }
         }
     },
 
@@ -56,8 +58,16 @@ return {
 
     npc_unsettled = {
         text = "Alright… you're strange. I'm gonna go.",
+        onSelect = function() print("[Jayson seems uneasy.]") end,
         choices = {
             { text = "(Say nothing)", next = "end_convo" }
+        }
+    },
+
+    map_offer = {
+        text = "There's an old facility east of here. I'll mark it for you.",
+        choices = {
+            { text = "(Travel there)", map = "map02", state = "exploration" }
         }
     },
 

--- a/tests/test_dialogue_state.lua
+++ b/tests/test_dialogue_state.lua
@@ -1,0 +1,47 @@
+describe("dialogue_state", function()
+  local dialogue_state
+
+  before_each(function()
+    package.loaded["src.states.dialogue_state"] = nil
+    dialogue_state = require("src.states.dialogue_state")
+    inventory = require("src.inventory")
+    inventory:clear()
+    game = { flags = { currentMap = "map01" } }
+    currentMap = { load = function() end }
+    state = { set = function(newState, ctx) state.last = newState; state.ctx = ctx end }
+  end)
+
+  it("runs node onSelect when entering", function()
+    local flag = false
+    local tree = { start = { text = "hi", choices = {}, onSelect = function() flag = true end } }
+    dialogue_state:enter({ tree = tree })
+    assert.is_true(flag)
+  end)
+
+  it("awards reward on choice", function()
+    local tree = {
+      start = {
+        text = "take", choices = { { text = "yes", reward = { name = "Med" }, next = "end" } }
+      },
+      ["end"] = { text = "done", choices = {} }
+    }
+    dialogue_state:enter({ tree = tree })
+    dialogue_state:keypressed("1")
+    assert.are.equal(1, #inventory.items)
+    assert.are.equal("Med", inventory.items[1].name)
+  end)
+
+  it("loads map on choice", function()
+    local loaded = false
+    local fakeMap = { load = function() loaded = true end }
+    package.loaded["src.maps.map02"] = fakeMap
+    local tree = {
+      start = { text = "go", choices = { { text = "move", map = "map02", state = "exploration" } } }
+    }
+    dialogue_state:enter({ tree = tree })
+    dialogue_state:keypressed("1")
+    assert.is_true(loaded)
+    assert.are.equal(fakeMap, currentMap)
+    assert.are.equal("map02", game.flags.currentMap)
+  end)
+end)


### PR DESCRIPTION
## Summary
- support running effects when selecting dialogue choices
- run `onSelect` when reaching a dialogue node
- hook NPC interaction into state manager
- extend Jayson dialogue to include new reward and map transition choices
- test dialogue_state logic

## Testing
- `busted -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847749af99c8331b3c2c8711df6e459