### PR TITLE
Add status effect system to combat

### DIFF
--- a/tests/test_combat.lua
+++ b/tests/test_combat.lua
@@ -1,0 +1,25 @@
+describe("combat status effects", function()
+  local combat
+  before_each(function()
+    package.loaded["src.combat"] = nil
+    combat = require("src.combat")
+    state = { set = function() end }
+  end)
+
+  it("applies bleed on skill use", function()
+    combat:start({name="Dummy", hp=40, dmg=5})
+    combat:useSkill(1)
+    assert.are.equal("Bleed", combat.enemy.status[1].type)
+    assert.are.equal(1, combat.enemy.status[1].duration)
+    assert.are.equal(15, combat.enemy.hp)
+  end)
+
+  it("guard break increases next damage", function()
+    combat:start({name="Dummy", hp=40, dmg=5})
+    combat:useSkill(2)
+    assert.are.equal(30, combat.enemy.hp)
+    combat:enemyAction()
+    combat:useSkill(1)
+    assert.are.equal(0, combat.enemy.hp)
+  end)
+end)


### PR DESCRIPTION
## Summary
- add status effect tracking to the combat module
- extend player skill definitions with Bleed and Guard Break effects
- apply/tick statuses each turn and show them on the combat UI
- add new test coverage for combat status effects

## Testing
- `busted -o plain -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684775c7b7a48331b6dca1996a95e62a