### PR TITLE
Add basic NPC AI behavior

### DIFF
--- a/src/npc/ai.lua
+++ b/src/npc/ai.lua
@@ -1,0 +1,53 @@
+--========================================
+-- ai.lua
+-- Basic roaming and hostile behaviour for NPCs
+--========================================
+
+local entityManager = require("src.entities.entity_manager")
+local map = require("src.map")
+local utils = require("src.utils")
+
+local npc_ai = {}
+
+-- Update all NPCs each frame
+function npc_ai:update(dt)
+    for _, e in ipairs(entityManager.entities) do
+        if e.type == "npc" then
+            -- Initialise AI fields
+            e.aiTimer = (e.aiTimer or 0) - dt
+            e.aiState = e.aiState or "idle"
+            e.dirIndex = e.dirIndex or math.random(#utils.directions)
+
+            if e.aiTimer <= 0 then
+                if e.aiState == "idle" then
+                    -- Idle: either rotate or start walking
+                    if math.random() < 0.5 then
+                        e.dirIndex = (e.dirIndex % #utils.directions) + 1
+                        e.aiTimer = 1
+                    else
+                        e.aiState = "walk"
+                    end
+                elseif e.aiState == "walk" then
+                    local dir = utils.directions[e.dirIndex]
+                    local nx, ny = e.x + dir.x, e.y + dir.y
+                    if map.isWalkable(nx, ny) and not entityManager:getAt(nx, ny) then
+                        e.x, e.y = nx, ny
+                    end
+                    e.aiState = "idle"
+                    e.aiTimer = 1
+                end
+            end
+
+            -- Hostile NPCs engage Krealer if adjacent
+            if e.hostile then
+                local dx = math.abs(player.x - e.x)
+                local dy = math.abs(player.y - e.y)
+                if dx + dy <= 1 then
+                    state:set("combat", { enemy = e })
+                end
+            end
+        end
+    end
+end
+
+return npc_ai

--- a/src/states/exploration_state.lua
+++ b/src/states/exploration_state.lua
@@ -7,6 +7,7 @@
 local exploration_state = {}
 local map = require("src.map")
 local interactions = require("src.interactions")
+local npcAI = require("src.npc.ai")
 
 -- Optional: track time since last interaction or event
 local interactionCooldown = 0.1
@@ -20,6 +21,7 @@ function exploration_state:update(dt)
     timer = timer - dt
 
     player:update(dt)
+    npcAI:update(dt)
 end
 
 function exploration_state:draw()

--- a/tests/test_npc_ai.lua
+++ b/tests/test_npc_ai.lua
@@ -1,0 +1,24 @@
+describe("npc ai", function()
+  local em, ai
+  before_each(function()
+    package.loaded["src.npc.ai"] = nil
+    package.loaded["src.entities.entity_manager"] = nil
+    em = require("src.entities.entity_manager")
+    em:clear()
+    ai = require("src.npc.ai")
+    config = require("src.config")
+    config.mapWidth = 3
+    config.mapHeight = 3
+    currentMap = { tiles = { {0,0,0},{0,0,0},{0,0,0} } }
+    player = { x = 1, y = 1 }
+    state = { set = function(_, s, ctx) state.called = s; state.ctx = ctx end }
+  end)
+
+  it("engages hostile NPC near player", function()
+    local npc = { x = 2, y = 1, type = "npc", name = "Rogue", hostile = true, hp = 30, dmg = 5 }
+    em:add(npc)
+    ai:update(0)
+    assert.are.equal("combat", state.called)
+    assert.are.equal(npc, state.ctx.enemy)
+  end)
+end)


### PR DESCRIPTION
## Summary
- create `src/npc/ai.lua` implementing walking/idle loops and hostile triggers
- update exploration state to run NPC AI each update
- add tests covering hostile engagement logic

## Testing
- `busted -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68477854688883318ab9d0bfcc3fdc2e