### PR TITLE
Enable combat inventory usage

### DIFF
--- a/src/combat.lua
+++ b/src/combat.lua
@@ -123,6 +123,21 @@ function combat:useSkill(index)
 end
 
 --========================================
+-- Use an inventory item during player's turn
+--========================================
+function combat:useItem(item)
+    if not item then return end
+
+    inventory:use(item)
+
+    self:checkOutcome()
+    if self.active then
+        self.playerTurn = false
+        startTurn(self.enemy)
+    end
+end
+
+--========================================
 -- Enemy turn (basic AI)
 --========================================
 function combat:enemyAction()
@@ -193,6 +208,8 @@ function combat:keypressed(key)
     local index = tonumber(key)
     if index and index >= 1 and index <= #self.player.skills then
         self:useSkill(index)
+    elseif input:matches(key, config.controls.inventory) then
+        state:set("inventory", { returnTo = "combat" })
     elseif key == "escape" then
         print("[Combat manually exited]")
         self.active = false

--- a/src/config.lua
+++ b/src/config.lua
@@ -38,7 +38,8 @@ config.controls = {
     right    = {"d", "right"},
     interact = {"space", "return"},
     cancel   = {"escape"},
-    confirm  = {"return"}
+    confirm  = {"return"},
+    inventory = {"i"}
 }
 
 return config

--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -64,7 +64,7 @@ end
 function player:keypressed(key)
     if key == "space" or key == "return" then
         interactions.check()
-    elseif key == "i" then
+    elseif input:matches(key, config.controls.inventory) then
         state:set("inventory")
     end
 end

--- a/src/inventory.lua
+++ b/src/inventory.lua
@@ -50,6 +50,17 @@ function inventory:use(item)
         print("Consumed " .. item.name .. ". Restored " .. gain .. " MP.")
         self:remove(self:indexOf(item))
 
+    elseif item.type == "boost" then
+        local stat = item.stat
+        local amount = item.effect or 0
+        if stat and combat.player[stat] then
+            combat.player[stat] = combat.player[stat] + amount
+            print("Used " .. item.name .. ". " .. stat .. " increased by " .. amount .. ".")
+        else
+            print("Used " .. item.name .. ".")
+        end
+        self:remove(self:indexOf(item))
+
     else
         print("Used " .. item.name .. ".")
         self:remove(self:indexOf(item))

--- a/src/state.lua
+++ b/src/state.lua
@@ -34,7 +34,7 @@ function state:set(newState, context)
     elseif newState == "combat" then
         combat:start(context.enemy)
     elseif newState == "inventory" then
-        inventoryUI:enter()
+        inventoryUI:enter(context)
     end
 end
 

--- a/src/states/inventory_state.lua
+++ b/src/states/inventory_state.lua
@@ -7,10 +7,12 @@
 local inventory_state = {}
 
 local selectedIndex = 1
+local returnState = "exploration"
 
-function inventory_state:enter()
+function inventory_state:enter(context)
     print("[Inventory opened]")
     selectedIndex = 1
+    returnState = (context and context.returnTo) or "exploration"
 end
 
 function inventory_state:update(dt)
@@ -45,9 +47,10 @@ function inventory_state:keypressed(key)
         local item = items[selectedIndex]
         if item then
             inventory:use(item)
+            state:set(returnState)
         end
     elseif key == "escape" then
-        state:set("exploration")
+        state:set(returnState)
     end
 end
 

--- a/tests/test_combat.lua
+++ b/tests/test_combat.lua
@@ -22,4 +22,14 @@ describe("combat status effects", function()
     combat:useSkill(1)
     assert.are.equal(0, combat.enemy.hp)
   end)
+
+  it("consumes turn when using an item", function()
+    combat:start({name="Dummy", hp=40, dmg=5})
+    inventory = require("src.inventory")
+    inventory.items = {}
+    local item = {name="Small Potion", type="healing", effect=10}
+    table.insert(inventory.items, item)
+    combat:useItem(item)
+    assert.is_false(combat.playerTurn)
+  end)
 end)

--- a/tests/test_inventory.lua
+++ b/tests/test_inventory.lua
@@ -36,6 +36,15 @@ describe("inventory", function()
     assert.are.equal(0, #inventory.items)
   end)
 
+  it("applies stat boosts", function()
+    local item = { name = "Doping", type = "boost", stat = "mp", effect = 5 }
+    inventory:add(item)
+    combat.player.mp = 5
+    inventory:use(item)
+    assert.are.equal(10, combat.player.mp)
+    assert.are.equal(0, #inventory.items)
+  end)
+
   it("finds index of an item", function()
     local item = { name = "FindMe" }
     inventory:add(item)


### PR DESCRIPTION
## Summary
- support inventory key mapping in config
- allow opening the inventory from combat and return afterwards
- implement combat item usage turn flow
- add boost item type
- use input mapping for inventory key on player
- cover new behaviours in tests

## Testing
- `busted -v` *(fails: `bash: busted: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684779a6fdf48331924c181655bee8ce