### PR TITLE
Implement basic field-of-view logic

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -67,6 +67,9 @@ function love.keypressed(key)
         love.window.setFullscreen(not fullscreen)
         print("Fullscreen: " .. tostring(not fullscreen))
         return
+    elseif key == "v" then
+        game.flags.showFOV = not game.flags.showFOV
+        return
     end
 
     -- Pass other keys to state manager

--- a/src/entities/entity_manager.lua
+++ b/src/entities/entity_manager.lua
@@ -16,6 +16,13 @@ entityManager.entities = {}
 function entityManager:add(entity)
     assert(entity.x and entity.y, "Entity must have x and y")
     assert(entity.type, "Entity must have a type")
+
+    if entity.type == "npc" or entity.type == "enemy" then
+        entity.visionRange = entity.visionRange or 3
+        entity.facing = entity.facing or "down"
+        entity.seenPlayer = entity.seenPlayer or false
+    end
+
     table.insert(self.entities, entity)
 end
 

--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -6,6 +6,7 @@
 local map = require("src.map")
 local entityManager = require("src.entities.entity_manager")
 local interactions = require("src.interactions")
+local utils = require("src.utils")
 
 player = {}
 
@@ -78,4 +79,17 @@ function player:draw()
     local tile = config.tileSize
     love.graphics.setColor(config.color.player)
     love.graphics.print(config.playerSymbol, self.x * tile + 8, self.y * tile + 8)
+end
+
+--========================================
+-- Check if player is inside an entity's FOV
+--========================================
+function player:isInFOV(entity)
+    local tiles = utils.getTilesInViewCone(entity.x, entity.y, entity.facing, entity.visionRange or 0)
+    for _, t in ipairs(tiles) do
+        if utils.isSamePos(t.x, t.y, self.x, self.y) then
+            return true
+        end
+    end
+    return false
 end

--- a/src/game.lua
+++ b/src/game.lua
@@ -21,7 +21,8 @@ game.flags = {
     reputation = 0,
     dialogueHistory = {},
     npc = {},                -- per-NPC persistent memory
-    sharedFlags = {}         -- optional flags shared between NPCs
+    sharedFlags = {},        -- optional flags shared between NPCs
+    showFOV = false
 }
 
 --========================================
@@ -63,4 +64,21 @@ function game:drawDebug(x, y)
     love.graphics.print("Player: " .. player.x .. "," .. player.y, x, y + 45)
     love.graphics.print("Map: " .. tostring(game.flags.currentMap), x, y + 60)
     love.graphics.print("HP: " .. combat.player.hp .. " | MP: " .. combat.player.mp, x, y + 75)
+end
+
+--========================================
+-- Draw fields of view for debugging
+--========================================
+function game:drawFOVOverlay()
+    if not game.flags.showFOV then return end
+    local tile = config.tileSize
+    love.graphics.setColor(0, 0.6, 1, 0.3)
+    for _, e in ipairs(entityManager.entities) do
+        if e.visionRange then
+            local tiles = utils.getTilesInViewCone(e.x, e.y, e.facing, e.visionRange)
+            for _, t in ipairs(tiles) do
+                love.graphics.rectangle("line", (t.x - 1) * tile, (t.y - 1) * tile, tile, tile)
+            end
+        end
+    end
 end

--- a/src/interactions.lua
+++ b/src/interactions.lua
@@ -42,4 +42,12 @@ function interactions.check()
     print("There's nothing to engage with.")
 end
 
+--========================================
+-- Called when a hostile entity spots the player
+--========================================
+function interactions.alert(entity)
+    print("[!] " .. (entity.name or "Enemy") .. " spotted you!")
+    state:set("combat", { enemy = entity })
+end
+
 return interactions

--- a/src/map.lua
+++ b/src/map.lua
@@ -66,6 +66,7 @@ function map.draw(tileGrid)
     -- Draw entities + player in scaled space
     entityManager:draw()
     player:draw()
+    game:drawFOVOverlay()
 
     love.graphics.pop() -- Reset transform for UI
 end

--- a/src/states/exploration_state.lua
+++ b/src/states/exploration_state.lua
@@ -8,6 +8,8 @@ local exploration_state = {}
 local map = require("src.map")
 local interactions = require("src.interactions")
 local npcAI = require("src.npc.ai")
+local entityManager = require("src.entities.entity_manager")
+local utils = require("src.utils")
 
 -- Optional: track time since last interaction or event
 local interactionCooldown = 0.1
@@ -22,6 +24,19 @@ function exploration_state:update(dt)
 
     player:update(dt)
     npcAI:update(dt)
+
+    for _, e in ipairs(entityManager.entities) do
+        if e.visionRange then
+            if player:isInFOV(e) then
+                e.seenPlayer = true
+                if e.hostile then
+                    interactions.alert(e)
+                end
+            else
+                e.seenPlayer = false
+            end
+        end
+    end
 end
 
 function exploration_state:draw()

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -61,4 +61,34 @@ utils.directions = {
     {x = 1, y = 0}   -- right
 }
 
+-- Direction name lookup
+utils.directionVectors = {
+    up    = { x = 0, y = -1 },
+    down  = { x = 0, y = 1 },
+    left  = { x = -1, y = 0 },
+    right = { x = 1, y = 0 }
+}
+
+--========================================
+-- Return tiles in a simple vision cone
+-- Expands one tile to the sides per step
+--========================================
+function utils.getTilesInViewCone(x, y, direction, range)
+    local dir = utils.directionVectors[direction]
+    if not dir then return {} end
+
+    local tiles = {}
+    local perp = { x = -dir.y, y = dir.x }
+
+    for i = 1, range do
+        local cx = x + dir.x * i
+        local cy = y + dir.y * i
+        table.insert(tiles, { x = cx, y = cy })
+        table.insert(tiles, { x = cx + perp.x, y = cy + perp.y })
+        table.insert(tiles, { x = cx - perp.x, y = cy - perp.y })
+    end
+
+    return tiles
+end
+
 return utils

--- a/tests/test_entity_manager.lua
+++ b/tests/test_entity_manager.lua
@@ -17,4 +17,12 @@ describe("entity_manager", function()
     em:clear()
     assert.are.equal(0, #em.entities)
   end)
+
+  it("initializes default vision fields", function()
+    local e = { x=1, y=1, type="enemy", name="Guard" }
+    em:add(e)
+    assert.are.equal(3, e.visionRange)
+    assert.are.equal("down", e.facing)
+    assert.is_false(e.seenPlayer)
+  end)
 end)

--- a/tests/test_fov.lua
+++ b/tests/test_fov.lua
@@ -1,0 +1,18 @@
+describe("fov detection", function()
+  before_each(function()
+    package.loaded["src.entities.player"] = nil
+    package.loaded["src.utils"] = nil
+    package.loaded["src.entities.entity_manager"] = nil
+    config = require("src.config")
+    utils = require("src.utils")
+    entityManager = require("src.entities.entity_manager")
+    player = require("src.entities.player")
+    player.x = 3
+    player.y = 1
+  end)
+
+  it("detects player inside enemy cone", function()
+    local enemy = { x = 1, y = 1, type = "enemy", name = "Guard", facing = "right", visionRange = 3 }
+    assert.is_true(player:isInFOV(enemy))
+  end)
+end)

--- a/tests/test_utils.lua
+++ b/tests/test_utils.lua
@@ -19,4 +19,11 @@ describe("utils", function()
     assert.are_not.equal(orig.b, copy.b)
     assert.are.same(orig, copy)
   end)
+
+  it("calculates vision cone tiles", function()
+    local tiles = utils.getTilesInViewCone(2,2,"right",2)
+    assert.are.equal(6, #tiles)
+    local last = tiles[#tiles]
+    assert.are.same({x=4, y=1}, last)
+  end)
 end)


### PR DESCRIPTION
## Summary
- add getTilesInViewCone helper
- set default vision fields when spawning entities
- allow the player to check if they are in an entity's FOV
- trigger alerts on hostile sighting
- render FOV regions in debug mode and toggle with `v`
- update exploration update loop for awareness checks
- add unit tests for new utilities and behaviours

## Testing
- `busted -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478335db54833193dcfcb9f2e47921