### PR TITLE
Add shrine interaction and healing

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -21,6 +21,7 @@ config.color = {
     npc    = {0, 1, 0},         -- Green
     enemy  = {1, 0, 0},         -- Red
     object = {1, 1, 0},         -- Yellow
+    shrine = {0.5, 0.8, 1},     -- Light blue
     player = {1, 1, 1},         -- White
     grid   = {0.3, 0.3, 0.3}    -- Grey grid lines
 }

--- a/src/entities/entity_manager.lua
+++ b/src/entities/entity_manager.lua
@@ -11,7 +11,7 @@ entityManager.entities = {}
 
 --========================================
 -- Add a new entity to the map
--- Required fields: x, y, type = "npc"/"enemy"/"object", name
+-- Required fields: x, y, type = "npc"/"enemy"/"object"/"shrine", name
 --========================================
 function entityManager:add(entity)
     assert(entity.x and entity.y, "Entity must have x and y")
@@ -67,6 +67,9 @@ function entityManager:draw()
         elseif e.type == "object" then
             char = "O"
             color = config.color.object
+        elseif e.type == "shrine" then
+            char = "S"
+            color = config.color.shrine or config.color.object
         end
 
         love.graphics.setColor(color)

--- a/src/game.lua
+++ b/src/game.lua
@@ -24,7 +24,8 @@ game.flags = {
     sharedFlags = {},        -- optional flags shared between NPCs
     showFOV = false,
     echoFlags = {},
-    zonesTriggered = {}
+    zonesTriggered = {},
+    shrinesVisited = {}
 }
 
 -- Conditioning metrics representing Null influence over Krealer

--- a/src/interactions.lua
+++ b/src/interactions.lua
@@ -34,6 +34,11 @@ function interactions.check()
                 local objects = require("src.entities.objects")
                 objects.interact(entity)
                 return
+            elseif entity.type == "shrine" then
+                local zone = require("src.zone")
+                zone.trigger("shrine_heal")
+                game.flags.shrinesVisited[entity.name] = true
+                return
             end
         end
     end

--- a/src/maps/map01.lua
+++ b/src/maps/map01.lua
@@ -37,7 +37,8 @@ function map:load()
 
     -- Place objects
     entityManager:add({ x = 4, y = 4, type = "object", name = "Chest", opened = false })
-    entityManager:add({ x = 5, y = 6, type = "object", name = "Healing Pit" })
+    -- Ritual pit that fully restores HP/MP when interacted with
+    entityManager:add({ x = 5, y = 6, type = "shrine", name = "Healing Pit" })
 
     -- Place enemies
     entityManager:add({ x = 7, y = 7, type = "enemy", name = "Null Agent", hp = 60, dmg = 12 })

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -126,6 +126,12 @@ function utils.triggerZone(name)
     zone.trigger(name)
 end
 
+-- Heal the player by amounts or to full when nil
+function utils.healPlayer(hp, mp)
+    combat.player.hp = math.min(combat.player.maxHp, (combat.player.hp or 0) + (hp or combat.player.maxHp))
+    combat.player.mp = math.min(combat.player.maxMp, (combat.player.mp or 0) + (mp or combat.player.maxMp))
+end
+
 -- Roll to resist Null conditioning influence
 function utils.rollConditioningCheck(difficulty)
     difficulty = difficulty or 50

--- a/src/zone_scripts/shrine_heal.lua
+++ b/src/zone_scripts/shrine_heal.lua
@@ -1,0 +1,11 @@
+-- Ritual healing shrine interaction
+local M = {}
+
+function M.run()
+    local utils = require("src.utils")
+    utils.healPlayer(combat.player.maxHp, combat.player.maxMp)
+    print("A calm voice whispers: 'Return to the fight.'")
+    return { state = "echo", context = { text = "Your wounds close in eerie silence", duration = 2 } }
+end
+
+return M


### PR DESCRIPTION
## Summary
- track shrine visits in game flags
- introduce color and drawing support for shrine entities
- add healing pit shrine to map01
- interact with shrine to trigger `shrine_heal` zone script
- new `healPlayer` helper for zone scripts
- new zone script `shrine_heal`

## Testing
- `busted -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480bcc6d8483319b1f93e973a37e2c