### PR TITLE
Add psyche progression system

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -18,6 +18,7 @@ local dialogue      = require("src.dialogue")
 local inventory     = require("src.inventory")
 local combat        = require("src.combat")
 local traits        = require("src.traits")
+local psyche        = require("src.psyche")
 
 --========================================
 -- love.load: Called once on game startup
@@ -70,6 +71,9 @@ function love.keypressed(key)
         return
     elseif key == "v" then
         game.flags.showFOV = not game.flags.showFOV
+        return
+    elseif key == "p" then
+        psyche:printUnlocked()
         return
     end
 

--- a/src/dialogue.lua
+++ b/src/dialogue.lua
@@ -6,6 +6,7 @@
 
 local dialogue = {}
 local game = require("src.game")
+local psyche = require("src.psyche")
 
 -- Helper to check memory requirements
 local function meetsRequirements(req, memory, shared)
@@ -123,6 +124,9 @@ function dialogue:getChoices()
         if ok and not meetsConditioning(choice.requiresConditioning) then
             ok = false
         end
+        if ok and choice.requiresSkill and not game.skillsUnlocked[choice.requiresSkill] then
+            ok = false
+        end
         if ok then
             table.insert(list, choice)
         end
@@ -134,7 +138,10 @@ end
 -- Advance to a new node by key
 -- Called when player makes a choice
 --========================================
-function dialogue:advanceTo(nextKey)
+function dialogue:advanceTo(nextKey, choice)
+    if choice and choice.psycheTag then
+        psyche:add(choice.psycheTag, 1)
+    end
     if not self.tree or not self.tree[nextKey] then
         print("[Warning] Missing dialogue node: " .. tostring(nextKey))
         self:reset()

--- a/src/game.lua
+++ b/src/game.lua
@@ -31,6 +31,17 @@ game.flags = {
 -- Conditioning metrics representing Null influence over Krealer
 game.conditioning = { influence = 70, resistance = 0 }
 
+-- Psyche progression metrics
+game.psyche = {
+    silence = 0,
+    logic = 0,
+    empathy = 0,
+    manipulation = 0
+}
+
+-- Set of unlocked psyche-based skills
+game.skillsUnlocked = {}
+
 --========================================
 -- Game boot logic (call in love.load)
 --========================================

--- a/src/inventory.lua
+++ b/src/inventory.lua
@@ -6,6 +6,8 @@
 
 inventory = {}
 
+local game = rawget(_G, "game")
+
 -- Holds item entries like:
 -- { name = "Null Salve", type = "healing", effect = 25 }
 inventory.items = {}
@@ -92,16 +94,29 @@ function inventory:draw()
     love.graphics.setColor(1, 1, 1)
     love.graphics.print("== INVENTORY ==", 20, 30)
 
+    local y = 40
     if #self.items == 0 then
-        love.graphics.print("Empty.", 40, 60)
-        return
+        love.graphics.print("Empty.", 40, y)
+    else
+        for i, item in ipairs(self.items) do
+            love.graphics.print(i .. ". " .. item.name .. " [" .. item.type .. "]", 40, y + i * 20)
+        end
     end
 
-    for i, item in ipairs(self.items) do
-        love.graphics.print(i .. ". " .. item.name .. " [" .. item.type .. "]", 40, 40 + i * 20)
+    y = y + (#self.items + 2) * 20
+    love.graphics.print("== SKILLS ==", 20, y)
+    local skills = (game and game.skillsUnlocked) or {}
+    local offset = y + 20
+    if next(skills) == nil then
+        love.graphics.print("None unlocked.", 40, offset)
+    else
+        for name,_ in pairs(skills) do
+            love.graphics.print("- " .. name, 40, offset)
+            offset = offset + 20
+        end
     end
 
-    love.graphics.print("[Enter] Use  |  [Esc] Back", 20, 300)
+    love.graphics.print("[Enter] Use  |  [Esc] Back", 20, offset + 20)
 end
 
 --========================================

--- a/src/psyche.lua
+++ b/src/psyche.lua
@@ -1,0 +1,52 @@
+local psyche = {}
+
+local game = require("src.game")
+
+psyche.thresholds = {
+    silence = { ["Silent Treatment"] = 3 },
+    logic = { ["Cold Read"] = 3 },
+    empathy = { ["Empathize"] = 3 },
+    manipulation = { ["Persuade"] = 3 }
+}
+
+psyche.descriptions = {
+    ["Silent Treatment"] = "Use silence to unsettle opponents.",
+    ["Cold Read"] = "Quickly analyze a person's motives.",
+    ["Empathize"] = "Better understand others' feelings.",
+    ["Persuade"] = "Subtly bend conversations your way."
+}
+
+function psyche:add(tag, amount)
+    amount = amount or 1
+    if game.psyche[tag] == nil then return end
+    game.psyche[tag] = game.psyche[tag] + amount
+    self:checkUnlocks(tag)
+end
+
+function psyche:checkUnlocks(tag)
+    local score = game.psyche[tag]
+    for skill, req in pairs(self.thresholds[tag] or {}) do
+        if score >= req and not game.skillsUnlocked[skill] then
+            game.skillsUnlocked[skill] = self.descriptions[skill] or true
+            print("[Skill Unlocked] " .. skill)
+        end
+    end
+end
+
+function psyche:getUnlocked()
+    return game.skillsUnlocked
+end
+
+function psyche:printUnlocked()
+    print("== Psyche Skills ==")
+    local any = false
+    for skill,_ in pairs(game.skillsUnlocked) do
+        print("* " .. skill)
+        any = true
+    end
+    if not any then
+        print("None unlocked.")
+    end
+end
+
+return psyche


### PR DESCRIPTION
## Summary
- add global psyche tracking and skill unlock tables
- implement psyche thresholds and skills in new `psyche.lua`
- integrate psyche gains and skill requirements in dialogue manager
- show unlocked skills in inventory UI
- allow viewing skills with `P` key

## Testing
- `busted -m 'src/?' --output plain` *(fails: busted not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68480ebfb4cc8331ae28781f646486aa