### PR TITLE
Add analytical journal logging system

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -40,7 +40,8 @@ config.controls = {
     interact = {"space", "return"},
     cancel   = {"escape"},
     confirm  = {"return"},
-    inventory = {"i"}
+    inventory = {"i"},
+    journal  = {"j"}
 }
 
 return config

--- a/src/dialogue.lua
+++ b/src/dialogue.lua
@@ -7,6 +7,7 @@
 local dialogue = {}
 local game = require("src.game")
 local psyche = require("src.psyche")
+local journal = require("src.journal")
 
 -- Helper to check memory requirements
 local function meetsRequirements(req, memory, shared)
@@ -142,6 +143,10 @@ function dialogue:advanceTo(nextKey, choice)
     if choice and choice.psycheTag then
         psyche:add(choice.psycheTag, 1)
     end
+    if choice and choice.journal then
+        local j = choice.journal
+        journal:addEntry(j.id, j.text, j.tags)
+    end
     if not self.tree or not self.tree[nextKey] then
         print("[Warning] Missing dialogue node: " .. tostring(nextKey))
         self:reset()
@@ -163,6 +168,10 @@ function dialogue:advanceTo(nextKey, choice)
     end
 
     self.currentNode = nextNode
+    if nextNode.journal then
+        local j = nextNode.journal
+        journal:addEntry(j.id, j.text, j.tags)
+    end
 end
 
 --========================================

--- a/src/game.lua
+++ b/src/game.lua
@@ -42,6 +42,9 @@ game.psyche = {
 -- Set of unlocked psyche-based skills
 game.skillsUnlocked = {}
 
+-- Stored journal logs
+game.journalEntries = {}
+
 --========================================
 -- Game boot logic (call in love.load)
 --========================================

--- a/src/input.lua
+++ b/src/input.lua
@@ -61,3 +61,10 @@ function input:getNumberPressed(key)
     end
     return nil
 end
+
+--========================================
+-- Convenience for journal toggle
+--========================================
+function input:isJournalToggle(key)
+    return self:matches(key, "journal")
+end

--- a/src/journal.lua
+++ b/src/journal.lua
@@ -1,0 +1,48 @@
+--========================================
+-- journal.lua
+-- Records notable observations in an analytical tone
+--========================================
+
+journal = {}
+
+-- Use persistent table from game if available
+journal.entries = game and game.journalEntries or {}
+
+--========================================
+-- Add a new journal entry
+-- id: unique identifier
+-- text: log content
+-- tags: optional list for categorisation
+--========================================
+function journal:addEntry(id, text, tags)
+    if not id or not text then return end
+    if self.entries[id] then return end
+    local entry = { id = id, text = text, tags = tags }
+    self.entries[id] = entry
+    if game and game.journalEntries then
+        game.journalEntries[id] = entry
+    end
+    print("[Journal] Logged entry: " .. id)
+end
+
+--========================================
+-- Draw journal entries
+--========================================
+function journal:draw()
+    love.graphics.setColor(1, 1, 1)
+    love.graphics.print("== JOURNAL ==", 20, 20)
+    local y = 40
+    local empty = true
+    for _, entry in pairs(self.entries) do
+        love.graphics.print("- " .. entry.text, 40, y)
+        y = y + 20
+        empty = false
+    end
+    if empty then
+        love.graphics.print("No observations recorded.", 40, y)
+        y = y + 20
+    end
+    love.graphics.print("[J] Close", 20, y + 20)
+end
+
+return journal

--- a/src/state.lua
+++ b/src/state.lua
@@ -19,6 +19,7 @@ local combat      = require("src.states.combat_state")
 local inventoryUI = require("src.states.inventory_state")
 local controlsUI  = require("src.states.controls_state")
 local echo        = require("src.states.echo_state")
+local journalUI   = require("src.states.journal_state")
 
 --========================================
 -- Trigger a Null hallucination effect and return to current state
@@ -56,6 +57,8 @@ function state:set(newState, context)
         controlsUI:enter(context)
     elseif newState == "echo" then
         echo:enter(context)
+    elseif newState == "journal" then
+        journalUI:enter(context)
     end
 end
 
@@ -89,6 +92,8 @@ function state:update(dt)
         controlsUI:update(dt)
     elseif currentState == "echo" then
         echo:update(dt)
+    elseif currentState == "journal" then
+        journalUI:update(dt)
     end
 end
 
@@ -111,6 +116,9 @@ function state:draw()
         controlsUI:draw()
     elseif currentState == "echo" then
         echo:draw()
+    elseif currentState == "journal" then
+        exploration:draw()
+        journalUI:draw()
     end
 end
 
@@ -130,5 +138,7 @@ function state:keypressed(key)
         controlsUI:keypressed(key)
     elseif currentState == "echo" then
         echo:keypressed(key)
+    elseif currentState == "journal" then
+        journalUI:keypressed(key)
     end
 end

--- a/src/states/dialogue_state.lua
+++ b/src/states/dialogue_state.lua
@@ -20,6 +20,7 @@ end
 local inventory = require("src.inventory")
 local game = require("src.game")
 local traits = require("src.traits")
+local journal = require("src.journal")
 
 local function processChoice(choice)
     if not choice then return end
@@ -36,6 +37,10 @@ local function processChoice(choice)
     if choice.historyKey then
         game.flags.dialogueHistory[choice.historyKey] = true
     end
+    if choice.journal then
+        local j = choice.journal
+        journal:addEntry(j.id, j.text, j.tags)
+    end
     if choice.state then
         state:set(choice.state)
         if choice.state ~= "dialogue" then
@@ -49,6 +54,10 @@ local function processChoice(choice)
     end
     if nextNode then
         currentNode = nextNode
+        if nextNode.journal then
+            local j = nextNode.journal
+            journal:addEntry(j.id, j.text, j.tags)
+        end
         if currentNode.onSelect then currentNode.onSelect() end
         if currentNode.triggerNull then
             state:nullTrigger({ text = currentNode.text })
@@ -96,6 +105,10 @@ function dialogue_state:enter(context)
         end
     end
     currentNode = startNode
+    if currentNode.journal then
+        local j = currentNode.journal
+        journal:addEntry(j.id, j.text, j.tags)
+    end
 
     if currentNode.onSelect then
         currentNode.onSelect()

--- a/src/states/exploration_state.lua
+++ b/src/states/exploration_state.lua
@@ -61,6 +61,8 @@ function exploration_state:keypressed(key)
         timer = interactionCooldown
     elseif key == "f2" then
         state:set("controls")
+    elseif input:isJournalToggle(key) then
+        state:set("journal", { returnTo = "exploration" })
     end
 end
 

--- a/src/states/journal_state.lua
+++ b/src/states/journal_state.lua
@@ -1,0 +1,25 @@
+--========================================
+-- journal_state.lua
+-- View Krealer's analytical journal
+--========================================
+
+local journal_state = {}
+local returnState = "exploration"
+
+function journal_state:enter(context)
+    returnState = (context and context.returnTo) or "exploration"
+end
+
+function journal_state:update(dt) end
+
+function journal_state:draw()
+    journal:draw()
+end
+
+function journal_state:keypressed(key)
+    if input:matches(key, config.controls.journal) or key == "escape" then
+        state:set(returnState)
+    end
+end
+
+return journal_state

--- a/src/zone_scripts/flash_training.lua
+++ b/src/zone_scripts/flash_training.lua
@@ -2,6 +2,9 @@ local M = {}
 
 function M.run()
     print("[Null training flashback]")
+    if journal then
+        journal:addEntry("flash_training", "Brief resurgence of Null training memories.", {"memory"})
+    end
     return { state = "echo", context = { text = "Memories of brutal Null training surge", duration = 2 } }
 end
 

--- a/src/zone_scripts/shrine01.lua
+++ b/src/zone_scripts/shrine01.lua
@@ -9,6 +9,9 @@ function M.run()
     if game and game.addReputation then
         game:addReputation("faith", 1)
     end
+    if journal then
+        journal:addEntry("shrine01", "Healing anomaly encountered at remote shrine.", {"location"})
+    end
     -- Return state change instruction
     return { state = "echo", context = { text = "An ancient shrine shimmers in your mind", duration = 2 } }
 end

--- a/src/zone_scripts/shrine_heal.lua
+++ b/src/zone_scripts/shrine_heal.lua
@@ -5,6 +5,9 @@ function M.run()
     local utils = require("src.utils")
     utils.healPlayer(combat.player.maxHp, combat.player.maxMp)
     print("A calm voice whispers: 'Return to the fight.'")
+    if journal then
+        journal:addEntry("shrine_heal", "Wounds closed at shrine without standard medicine.", {"anomaly"})
+    end
     return { state = "echo", context = { text = "Your wounds close in eerie silence", duration = 2 } }
 end
 


### PR DESCRIPTION
## Summary
- create `journal.lua` to track analytical logs
- create `journal_state` UI module
- add journal state handling in `state.lua`
- enable journal toggle in exploration
- map `J` key in `config.lua` and helper function in `input.lua`
- persist entries in `game.lua`
- log observations in zone scripts
- allow dialogue nodes and choices to write journal entries

## Testing
- `busted` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684810d4f7e88331bc5a192ae4198af7