### PR TITLE
Add surveillance zone mechanic

### DIFF
--- a/src/game.lua
+++ b/src/game.lua
@@ -45,6 +45,12 @@ game.skillsUnlocked = {}
 -- Stored journal logs
 game.journalEntries = {}
 
+-- Current alert level from Null surveillance systems
+game.alertLevel = 0
+
+-- Per-zone timers tracking how long Krealer has been detected
+game.surveillanceTimers = {}
+
 --========================================
 -- Game boot logic (call in love.load)
 --========================================

--- a/src/input.lua
+++ b/src/input.lua
@@ -68,3 +68,8 @@ end
 function input:isJournalToggle(key)
     return self:matches(key, "journal")
 end
+
+-- Optional stealth modifier key
+function input:isStealth()
+    return love.keyboard.isDown("lshift") or love.keyboard.isDown("rshift") or love.keyboard.isDown("l")
+end

--- a/src/map.lua
+++ b/src/map.lua
@@ -77,6 +77,25 @@ end
 function map.update(dt)
     if not currentMap or not currentMap.tiles then return end
 
+    -- Handle surveillance zones
+    if currentMap.surveillanceZones then
+        for i, zone in ipairs(currentMap.surveillanceZones) do
+            if utils.isInZone(player.x, player.y, zone) then
+                local inc = dt
+                if input.isStealth and input:isStealth() then
+                    inc = inc * 0.5
+                end
+                game.surveillanceTimers[i] = (game.surveillanceTimers[i] or 0) + inc
+                if game.surveillanceTimers[i] >= (zone.threshold or 3) then
+                    game.surveillanceTimers[i] = 0
+                    utils.triggerZone("surveillance_trigger")
+                end
+            else
+                game.surveillanceTimers[i] = 0
+            end
+        end
+    end
+
     local tileData = currentMap.tiles[player.y] and currentMap.tiles[player.y][player.x]
     if type(tileData) == "table" then
         if tileData.echo_trigger then

--- a/src/maps/map01.lua
+++ b/src/maps/map01.lua
@@ -24,6 +24,11 @@ map.tiles = {
     {1,1,1,1,1,1,1,1,1,1}
 }
 
+-- Zones monitored by Null surveillance
+map.surveillanceZones = {
+    { x1 = 3, y1 = 4, x2 = 7, y2 = 6 }
+}
+
 map.exits = {
     { x = 10, y = 5, map = "map02", toX = 2, toY = 5 }
 }

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -16,6 +16,12 @@ function utils.isSamePos(x1, y1, x2, y2)
     return x1 == x2 and y1 == y2
 end
 
+-- Check if a coordinate falls within a rectangular zone
+function utils.isInZone(x, y, zone)
+    if not zone then return false end
+    return x >= zone.x1 and x <= zone.x2 and y >= zone.y1 and y <= zone.y2
+end
+
 -- Deep copy a table (used to duplicate templates without linking)
 function utils.deepcopy(orig)
     local orig_type = type(orig)

--- a/src/zone_scripts/surveillance_trigger.lua
+++ b/src/zone_scripts/surveillance_trigger.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.run()
+    print("[Surveillance triggered]")
+    game.alertLevel = (game.alertLevel or 0) + 1
+    if journal then
+        journal:addEntry("surveillance", "Detected lingering in surveillance zone.", {"danger"})
+    end
+    return { state = "echo", context = { text = "Alarms blare as enforcers approach", duration = 2 } }
+end
+
+return M

--- a/tests/test_utils.lua
+++ b/tests/test_utils.lua
@@ -12,6 +12,12 @@ describe("utils", function()
     assert.is_false(utils.isSamePos(1,2,2,1))
   end)
 
+  it("checks coordinates inside zones", function()
+    local zone = {x1=1, y1=1, x2=3, y2=3}
+    assert.is_true(utils.isInZone(2,2,zone))
+    assert.is_false(utils.isInZone(4,2,zone))
+  end)
+
   it("deepcopies tables", function()
     local orig = {a=1,b={c=2}}
     local copy = utils.deepcopy(orig)


### PR DESCRIPTION
## Summary
- define surveillanceZones in map01
- track alert levels in `game`
- detect player staying in zones via `map.update`
- add isInZone helper
- add optional stealth key detection
- create `surveillance_trigger` zone script
- test new utils helper

## Testing
- `busted -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684819b574f483319ca89a05c93124ab