### PR TITLE
Fix circular require in map module

### DIFF
--- a/src/map.lua
+++ b/src/map.lua
@@ -5,7 +5,10 @@
 --========================================
 
 local entityManager = require("src.entities.entity_manager")
-local state = require("src.state")
+-- State is required lazily to avoid circular dependencies
+local function getState()
+    return require("src.state")
+end
 
 local map = {}
 
@@ -102,7 +105,7 @@ function map.update(dt)
             local id = tileData.id or (game.flags.currentMap .. ":" .. player.x .. ":" .. player.y)
             if not game.flags.echoFlags[id] then
                 game.flags.echoFlags[id] = true
-                state:set("echo", { text = tileData.text, duration = tileData.duration or 1.5 })
+                getState():set("echo", { text = tileData.text, duration = tileData.duration or 1.5 })
             end
         end
 


### PR DESCRIPTION
## Summary
- avoid requiring `src.state` at module load
- defer `src.state` load inside `getState` helper

This prevents a circular dependency between `map.lua` and `state.lua` which previously caused:
```
src/map.lua:8: loop or previous error loading module 'src.state'
```

## Testing
- `busted -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684827d14860833199b5104b7487b761